### PR TITLE
separate config

### DIFF
--- a/autokindle/logging/__init__.py
+++ b/autokindle/logging/__init__.py
@@ -1,2 +1,1 @@
-from autokindle.logging.config import setupLogging
 from autokindle.logging.loggers import getLogger

--- a/autokindle/logging/config.py
+++ b/autokindle/logging/config.py
@@ -1,9 +1,0 @@
-from __future__ import absolute_import
-import logging
-
-def setupLogging():
-    logging.basicConfig(
-        level=logging.DEBUG,
-        format='%(asctime)s %(process)d/%(package)s %(levelname)s/%(simpleName)s: %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
-    )

--- a/autokindle/logging/handlers.py
+++ b/autokindle/logging/handlers.py
@@ -1,0 +1,9 @@
+from __future__ import absolute_import
+import logging
+
+def Handler():
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(
+            '%(asctime)s %(process)d/%(package)s %(levelname)s/%(simpleName)s: %(message)s',
+            '%Y-%m-%d %H:%M:%S'))
+        return handler

--- a/autokindle/logging/loggers.py
+++ b/autokindle/logging/loggers.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import
 import logging
 from autokindle.logging.filters import Filter
+from autokindle.logging.handlers import Handler
 
 
 def getLogger(package, name):
     logger = logging.getLogger(f'{package}.{name}')
+    logger.setLevel(logging.DEBUG)
     logger.addFilter(Filter(package, name))
+    logger.addHandler(Handler())
     return logger

--- a/autokindle/main.py
+++ b/autokindle/main.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from autokindle.logging import getLogger, setupLogging
+from autokindle.logging import getLogger
 from autokindle.state import Store, reducer
 from autokindle.watchdog.handlers import FileHandler, KindleConnectionHandler
 from autokindle.watchdog import start_watching
@@ -8,7 +8,6 @@ from autokindle.state.observables import initialize, new_files, connection_statu
 import rx
 
 
-setupLogging()
 logger = getLogger(__name__, 'main')
 
 


### PR DESCRIPTION
Removing `basicConfig` which caused errors for a third-party to log debug messages, arranged a dedicated configuration for the particular logger only used by our application.